### PR TITLE
Eval the TEAMCITY_CAPTURE_ENV as TC is now passing double quotes as of 8.1.3

### DIFF
--- a/agent/src/com/jonnyzzz/teamcity/plugins/node/agent/nvm/NVM.kt
+++ b/agent/src/com/jonnyzzz/teamcity/plugins/node/agent/nvm/NVM.kt
@@ -111,7 +111,7 @@ public class NVMRunner(val downloader : NVMDownloader,
           ". ${nvmHome}/nvm.sh" n "nvm install ${fromSource} ${version}"
         }
         script("Use", "Selecting Node.js v${version}",nvmHome.getPath()) {
-          ". ${nvmHome}/nvm.sh" n "nvm use ${version}" n "\eval ${TEAMCITY_CAPTURE_ENV}"
+          ". ${nvmHome}/nvm.sh" n "nvm use ${version}" n "eval \${TEAMCITY_CAPTURE_ENV}"
         }
       }
     }


### PR DESCRIPTION
Fixes #53
