### PR TITLE
Added support for yarn runner

### DIFF
--- a/.idea/runConfigurations/Server.xml
+++ b/.idea/runConfigurations/Server.xml
@@ -5,7 +5,7 @@
     <option name="COMMON_VM_ARGUMENTS" value="-ea -Xmx384m -XX:MaxPermSize=200m -Ddebug=true -server -XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless -DTC.res.disableAll=true -Dteamcity.development.mode=true -Dteamcity.development.shadowCopyClasses=true -Dteamcity.data.path=$TeamCityDistribution$/../PluginDev.Data -Dteamcity_logs=$TeamCityDistribution$/logs -Dlog4j.configuration=file:$TeamCityDistribution$/conf/teamcity-server-log4j.xml" />
     <option name="UPDATING_POLICY" value="restart-server" />
     <deployment>
-      <file path="$APPLICATION_HOME_DIR$/bin/Users/fkrauthan/TeamCity/webapps/ROOT">
+      <file path="$TeamCityDistribution$/webapps/ROOT">
         <settings>
           <option name="CONTEXT_PATH" value="/bs" />
         </settings>

--- a/.idea/runConfigurations/Server.xml
+++ b/.idea/runConfigurations/Server.xml
@@ -5,7 +5,7 @@
     <option name="COMMON_VM_ARGUMENTS" value="-ea -Xmx384m -XX:MaxPermSize=200m -Ddebug=true -server -XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless -DTC.res.disableAll=true -Dteamcity.development.mode=true -Dteamcity.development.shadowCopyClasses=true -Dteamcity.data.path=$TeamCityDistribution$/../PluginDev.Data -Dteamcity_logs=$TeamCityDistribution$/logs -Dlog4j.configuration=file:$TeamCityDistribution$/conf/teamcity-server-log4j.xml" />
     <option name="UPDATING_POLICY" value="restart-server" />
     <deployment>
-      <file path="$TeamCityDistribution$/webapps/ROOT">
+      <file path="$APPLICATION_HOME_DIR$/bin/Users/fkrauthan/TeamCity/webapps/ROOT">
         <settings>
           <option name="CONTEXT_PATH" value="/bs" />
         </settings>

--- a/agent/src/META-INF/build-agent-plugin-node.xml
+++ b/agent/src/META-INF/build-agent-plugin-node.xml
@@ -12,6 +12,7 @@
 
   <bean class="com.jonnyzzz.teamcity.plugins.node.agent.node.NodeJsRunnerService"/>
   <bean class="com.jonnyzzz.teamcity.plugins.node.agent.npm.NPMServiceFactory"/>
+  <bean class="com.jonnyzzz.teamcity.plugins.node.agent.yarn.YarnServiceFactory"/>
 
   <bean class="com.jonnyzzz.teamcity.plugins.node.agent.NodeToolsDetector"/>
   <bean class="com.jonnyzzz.teamcity.plugins.node.agent.phantom.PhantomJsRunnerService"/>

--- a/agent/src/com/jonnyzzz/teamcity/plugins/node/agent/NodeDetector.kt
+++ b/agent/src/com/jonnyzzz/teamcity/plugins/node/agent/NodeDetector.kt
@@ -90,6 +90,7 @@ class NodeToolsDetector(events: EventDispatcher<AgentLifeCycleListener>,
         }
 
         detectNodeTool("npm", NPMBean().nodeJSNPMConfigurationParameter)
+        detectNodeTool("yarn", YarnBean().nodeJSYarnConfigurationParameter)
 
         detectNodeTool("grunt", GruntBean().gruntConfigurationParameter) {
           it.trimStart("grunt-cli").trim().trimStart("v")

--- a/agent/src/com/jonnyzzz/teamcity/plugins/node/agent/yarn/YarnServiceFactory.kt
+++ b/agent/src/com/jonnyzzz/teamcity/plugins/node/agent/yarn/YarnServiceFactory.kt
@@ -27,8 +27,8 @@ import jetbrains.buildServer.serverSide.BuildTypeOptions
 import org.apache.log4j.Logger
 
 /**
- * Created by Eugene Petrenko (eugene.petrenko@gmail.com)
- * Date: 15.01.13 22:55
+ * Created by Florian Krauthan (mail@fkrauthan.de)
+ * Date: 19.01.17
  */
 
 class YarnServiceFactory : MultiCommandBuildSessionFactory {

--- a/agent/src/com/jonnyzzz/teamcity/plugins/node/agent/yarn/YarnServiceFactory.kt
+++ b/agent/src/com/jonnyzzz/teamcity/plugins/node/agent/yarn/YarnServiceFactory.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2013-2017 Eugene Petrenko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.jonnyzzz.teamcity.plugins.node.agent.yarn
+
+import com.jonnyzzz.teamcity.plugins.node.agent.processes.Execution
+import com.jonnyzzz.teamcity.plugins.node.agent.processes.ScriptWrappingCommandLineGenerator
+import com.jonnyzzz.teamcity.plugins.node.common.*
+import jetbrains.buildServer.BuildProblemData
+import jetbrains.buildServer.BuildProblemTypes
+import jetbrains.buildServer.agent.*
+import jetbrains.buildServer.agent.runner.*
+import jetbrains.buildServer.serverSide.BuildTypeOptions
+import org.apache.log4j.Logger
+
+/**
+ * Created by Eugene Petrenko (eugene.petrenko@gmail.com)
+ * Date: 15.01.13 22:55
+ */
+
+class YarnServiceFactory : MultiCommandBuildSessionFactory {
+  val bean = YarnBean()
+
+  override fun createSession(p0: BuildRunnerContext): MultiCommandBuildSession = YarnSession(p0)
+
+  override fun getBuildRunnerInfo(): AgentBuildRunnerInfo = object : AgentBuildRunnerInfo{
+    override fun getType(): String = bean.runTypeName
+    override fun canRun(agentConfiguration: BuildAgentConfiguration): Boolean = true
+  }
+}
+
+class YarnSession(val runner : BuildRunnerContext) : MultiCommandBuildSession {
+  private val bean = YarnBean()
+  private var iterator : Iterator<YarnCommandExecution> = listOf<YarnCommandExecution>().iterator()
+  private var previousStatus = BuildFinishedStatus.FINISHED_SUCCESS
+  private val logger = runner.build.buildLogger.getFlowLogger(FlowGenerator.generateNewFlow())
+
+  private fun resolveYarnExecutable() : String {
+    val path = runner.runnerParameters[bean.toolPathKey]
+    if (path == null || path.isEmptyOrSpaces()) return "yarn"
+    return path.trim()
+  }
+
+  override fun sessionStarted() {
+    logger.startFlow()
+
+    val extra = runner.runnerParameters[bean.commandLineParameterKey].fetchArguments()
+    val checkExitCode = runner.build.getBuildTypeOptionValue(BuildTypeOptions.BT_FAIL_ON_EXIT_CODE) ?: true
+    val yarn = resolveYarnExecutable()
+
+    iterator =
+            bean.parseCommands(runner.runnerParameters[bean.yarnCommandsKey])
+                    .map{ YarnCommandExecution(
+                    logger,
+                    "yarn $it",
+                    runner,
+                    Execution(yarn, extra + it.splitHonorQuotes())){ exitCode ->
+                      previousStatus = when {
+                        exitCode == 0 && checkExitCode -> BuildFinishedStatus.FINISHED_SUCCESS
+                        else -> BuildFinishedStatus.FINISHED_WITH_PROBLEMS
+                      }
+                    }
+            }.iterator()
+  }
+
+  override fun getNextCommand(): CommandExecution? =
+          when {
+            previousStatus != BuildFinishedStatus.FINISHED_SUCCESS -> null
+            iterator.hasNext() -> iterator.next()
+            else -> null
+          }
+
+  override fun sessionFinished(): BuildFinishedStatus {
+    logger.disposeFlow()
+    return previousStatus
+  }
+}
+
+class YarnCommandExecution(val logger : BuildProgressLogger,
+                                 val blockName : String,
+                                 val runner : BuildRunnerContext,
+                                 val cmd : Execution,
+                                 val onFinished : (Int) -> Unit) : LoggingProcessListener(logger), CommandExecution {
+  private val bean = YarnBean()
+  private val OUT_LOG : Logger? = Logger.getLogger("teamcity.out")
+  private val disposables = arrayListOf<() -> Unit>()
+
+  override fun makeProgramCommandLine(): ProgramCommandLine =
+          object:ScriptWrappingCommandLineGenerator<ProgramCommandLine>(runner) {
+            override fun execute(executable: String, args: List<String>): ProgramCommandLine
+                    = SimpleProgramCommandLine(build, executable, args)
+
+            override fun disposeLater(action: () -> Unit) {
+              disposables.add(action)
+            }
+          }.generate(cmd.program, cmd.arguments)
+
+
+  override fun beforeProcessStarted() {
+    logger.activityStarted(blockName, "yarn");
+  }
+
+  override fun onStandardOutput(text: String) {
+    if (text.contains("yarn ERR!")){
+      logger.error(text)
+      OUT_LOG?.warn(text)
+      return
+    }
+    super.onStandardOutput(text)
+  }
+
+  override fun onErrorOutput(text: String) {
+    if (text.contains("yarn ERR!")){
+      logger.error(text)
+      OUT_LOG?.warn(text)
+      return
+    }
+    super.onErrorOutput(text)
+  }
+
+  override fun processFinished(exitCode: Int) {
+    super.processFinished(exitCode)
+
+    if (exitCode != 0) {
+      logger.logBuildProblem(createExitCodeBuildProblem(exitCode))
+    }
+
+    logger.activityFinished(blockName, "yarn");
+    disposables.forEach { it() }
+    onFinished(exitCode)
+  }
+
+  // copy of jetbrains.buildServer.agent.runner.CommandLineBuildService.createExitCodeBuildProblem for backward compatibility
+  private fun createExitCodeBuildProblem(exitCode: Int): BuildProblemData {
+    return BuildProblemData.createBuildProblem(
+            bean.runTypeName + exitCode,
+            BuildProblemTypes.TC_EXIT_CODE_TYPE,
+            "Process exited with code " + exitCode, "teamcity.process.flow.id=" + logger.flowId)
+  }
+
+  override fun interruptRequested(): TerminationAction = TerminationAction.KILL_PROCESS_TREE
+  override fun isCommandLineLoggingEnabled(): Boolean = true
+}

--- a/common/src/com/jonnyzzz/teamcity/plugins/node/common/YarnBean.kt
+++ b/common/src/com/jonnyzzz/teamcity/plugins/node/common/YarnBean.kt
@@ -17,8 +17,8 @@
 package com.jonnyzzz.teamcity.plugins.node.common
 
 /**
- * Created by Eugene Petrenko (eugene.petrenko@gmail.com)
- * Date: 14.01.13 22:02
+ * Created by Florian Krauthan (mail@fkrauthan.de)
+ * Date: 19.01.17
  */
 
 class YarnBean {

--- a/common/src/com/jonnyzzz/teamcity/plugins/node/common/YarnBean.kt
+++ b/common/src/com/jonnyzzz/teamcity/plugins/node/common/YarnBean.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2017 Eugene Petrenko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.jonnyzzz.teamcity.plugins.node.common
+
+/**
+ * Created by Eugene Petrenko (eugene.petrenko@gmail.com)
+ * Date: 14.01.13 22:02
+ */
+
+class YarnBean {
+  val nodeJSYarnConfigurationParameter: String = "node.js.yarn"
+
+  val runTypeName: String = "jonnyzzz.yarn"
+  val commandLineParameterKey: String = "yarn_execution_args"
+  val yarnCommandsKey: String = "yarn_commands"
+  val yarnCommandsDefault: String = "install\r\ntest"
+  val toolPathKey : String = "yarn_toolPath"
+
+  fun parseCommands(text: String?): Collection<String> {
+    if (text == null || text.isEmpty())
+      return listOf()
+    else
+      return text
+              .lines()
+              .map { it.trim() }
+              .filterNot { it.isEmptyOrSpaces() }
+  }
+}

--- a/server/resources/node.yarn.edit.jsp
+++ b/server/resources/node.yarn.edit.jsp
@@ -1,0 +1,54 @@
+<%--
+  ~ Copyright 2013-2017 Eugene Petrenko
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+
+<%@ include file="/include.jsp"%>
+<%@ taglib prefix="forms" tagdir="/WEB-INF/tags/forms" %>
+<%@ taglib prefix="props" tagdir="/WEB-INF/tags/props" %>
+<%@ taglib prefix="l" tagdir="/WEB-INF/tags/layout" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+
+<jsp:useBean id="bean" class="com.jonnyzzz.teamcity.plugins.node.common.YarnBean"/>
+
+<tr>
+  <th><label for="${bean.yarnCommandsKey}">yarn commands:</label></th>
+  <td>
+    <props:multilineProperty name="${bean.yarnCommandsKey}" linkTitle="Commands" cols="58" rows="5" expanded="${true}"/>
+    <span class="smallNote">Specify yarn commands to run</span>
+    <span class="error" id="error_${bean.yarnCommandsKey}"></span>
+  </td>
+</tr>
+
+<l:settingsGroup title="Execution">
+<tr>
+  <th><label for="${bean.toolPathKey}">Path to Node.js Yarn:</label></th>
+  <td>
+    <props:textProperty name="${bean.toolPathKey}" className="longField"/>
+    <span class="smallNote">Specify path to Node.js Yarn executable. Leave blank to use agent-installed one</span>
+    <span class="error" id="error_${bean.toolPathKey}"></span>
+  </td>
+</tr>
+
+<forms:workingDirectory/>
+
+<tr>
+  <th><label for="${bean.commandLineParameterKey}">Additional command line parameters:</label></th>
+  <td>
+    <props:multilineProperty name="${bean.commandLineParameterKey}"  cols="58" linkTitle="Expand" rows="5"/>
+    <span class="smallNote">Enter additional command line parameters for npm. Put each parameter on a new line</span>
+    <span class="error" id="error_${bean.commandLineParameterKey}"></span>
+  </td>
+</tr>
+</l:settingsGroup>

--- a/server/resources/node.yarn.edit.jsp
+++ b/server/resources/node.yarn.edit.jsp
@@ -47,7 +47,7 @@
   <th><label for="${bean.commandLineParameterKey}">Additional command line parameters:</label></th>
   <td>
     <props:multilineProperty name="${bean.commandLineParameterKey}"  cols="58" linkTitle="Expand" rows="5"/>
-    <span class="smallNote">Enter additional command line parameters for npm. Put each parameter on a new line</span>
+    <span class="smallNote">Enter additional command line parameters for yarn. Put each parameter on a new line</span>
     <span class="error" id="error_${bean.commandLineParameterKey}"></span>
   </td>
 </tr>

--- a/server/resources/node.yarn.view.jsp
+++ b/server/resources/node.yarn.view.jsp
@@ -1,0 +1,38 @@
+<%--
+  ~ Copyright 2013-2017 Eugene Petrenko
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+
+<%@ include file="/include.jsp"%>
+<%@ taglib prefix="forms" tagdir="/WEB-INF/tags/forms" %>
+<%@ taglib prefix="props" tagdir="/WEB-INF/tags/props" %>
+<%@ taglib prefix="l" tagdir="/WEB-INF/tags/layout" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<jsp:useBean id="bean" class="com.jonnyzzz.teamcity.plugins.node.common.YarnBean"/>
+<jsp:useBean id="propertiesBean" scope="request" type="jetbrains.buildServer.controllers.BasePropertiesBean"/>
+
+<div class="parameter">
+  <!-- TODO: introduce controller to present targets in more readable way -->
+  Run targets: <props:displayValue name="${bean.yarnCommandsKey}" showInPopup="${true}" emptyValue="${bean.yarnCommandsDefault}"/>
+</div>
+
+<div class="parameter">
+  Yarn: <props:displayValue name="${bean.toolPathKey}" emptyValue="<default>"/>
+</div>
+
+<props:viewWorkingDirectory/>
+
+<div class="parameter">
+  Additional command line arguments: <props:displayValue name="${bean.commandLineParameterKey}" showInPopup="${true}" emptyValue="<empty>"/>
+</div>

--- a/server/src/META-INF/build-server-plugin-node.xml
+++ b/server/src/META-INF/build-server-plugin-node.xml
@@ -10,6 +10,7 @@
   <bean class="com.jonnyzzz.teamcity.plugins.node.server.RunTypesRegistrar"/>
   <bean class="com.jonnyzzz.teamcity.plugins.node.server.NodeJsRunType"/>
   <bean class="com.jonnyzzz.teamcity.plugins.node.server.NPMRunType"/>
+  <bean class="com.jonnyzzz.teamcity.plugins.node.server.YarnRunType"/>
   <bean class="com.jonnyzzz.teamcity.plugins.node.server.PhantomJsRunType"/>
   <bean class="com.jonnyzzz.teamcity.plugins.node.server.GruntRunType"/>
   <bean class="com.jonnyzzz.teamcity.plugins.node.server.GulpRunType"/>

--- a/server/src/com/jonnyzzz/teamcity/plugins/node/server/YarnRunType.kt
+++ b/server/src/com/jonnyzzz/teamcity/plugins/node/server/YarnRunType.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2017 Eugene Petrenko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.jonnyzzz.teamcity.plugins.node.server
+
+import jetbrains.buildServer.requirements.Requirement
+import jetbrains.buildServer.requirements.RequirementType
+import jetbrains.buildServer.serverSide.InvalidProperty
+import jetbrains.buildServer.serverSide.PropertiesProcessor
+import com.jonnyzzz.teamcity.plugins.node.common.isEmptyOrSpaces
+import com.jonnyzzz.teamcity.plugins.node.common.YarnBean
+
+/**
+ * Created by Eugene Petrenko (eugene.petrenko@gmail.com)
+ * Date: 14.01.13 21:57
+ */
+
+class YarnRunType : RunTypeBase() {
+  private val bean = YarnBean()
+
+  override fun getType(): String = bean.runTypeName
+  override fun getDisplayName(): String = "Node.js Yarn"
+  override fun getDescription(): String = "Starts Yarn"
+  override fun getEditJsp(): String = "node.yarn.edit.jsp"
+  override fun getViewJsp(): String = "node.yarn.view.jsp"
+
+  override fun getRunnerPropertiesProcessor(): PropertiesProcessor {
+    return object : PropertiesProcessor {
+      override fun process(parameters: Map<String, String>?): MutableCollection<InvalidProperty>?
+              = arrayListOf()
+    }
+  }
+
+  override fun describeParameters(parameters: Map<String, String>): String
+          = "Run targets: ${bean.parseCommands(parameters[bean.yarnCommandsKey]).joinToString(", ")}"
+
+  override fun getDefaultRunnerProperties(): MutableMap<String, String>?
+          = hashMapOf(bean.yarnCommandsKey to bean.yarnCommandsDefault)
+
+  override fun getRunnerSpecificRequirements(runParameters: Map<String, String>): MutableList<Requirement> {
+    val result = arrayListOf<Requirement>()
+    result.addAll(super.getRunnerSpecificRequirements(runParameters))
+
+    if (runParameters[bean.toolPathKey].isEmptyOrSpaces()) {
+      //for now there is the only option to use detected node.js
+      result.add(Requirement(bean.nodeJSYarnConfigurationParameter, null, RequirementType.EXISTS))
+    }
+    return result
+  }
+}

--- a/server/src/com/jonnyzzz/teamcity/plugins/node/server/YarnRunType.kt
+++ b/server/src/com/jonnyzzz/teamcity/plugins/node/server/YarnRunType.kt
@@ -24,8 +24,8 @@ import com.jonnyzzz.teamcity.plugins.node.common.isEmptyOrSpaces
 import com.jonnyzzz.teamcity.plugins.node.common.YarnBean
 
 /**
- * Created by Eugene Petrenko (eugene.petrenko@gmail.com)
- * Date: 14.01.13 21:57
+ * Created by Florian Krauthan (mail@fkrauthan.de)
+ * Date: 19.01.17
  */
 
 class YarnRunType : RunTypeBase() {


### PR DESCRIPTION
I started to add support for a yarn runner. This should already allow to execute a global installed yarn runner (I followed the same pattern as NPM runner works).

This is still WIP as I plan to add automatic install of yarn in case it was not successful detected.

Fixes #116 