### PR TITLE
Fixing incomplete Windows support [Issue #133]

### DIFF
--- a/agent/src/main/java/com/jonnyzzz/teamcity/plugins/node/agent/NodeDetector.kt
+++ b/agent/src/main/java/com/jonnyzzz/teamcity/plugins/node/agent/NodeDetector.kt
@@ -40,7 +40,7 @@ class NodeToolsDetector(events: EventDispatcher<AgentLifeCycleListener>,
   fun detectNVMTool() {
     with(config.systemInfo) {
       when {
-        isWindows && !File(System.getenv("APPDATA") + "\\nvm\\nvm.exe").isFile -> {
+        isWindows && !File(System.getenv("NVM_HOME") + "\\nvm\\nvm.exe").isFile -> {
           log4j(javaClass).info("Node NVM installer runner is not available.")
         }
 

--- a/agent/src/main/java/com/jonnyzzz/teamcity/plugins/node/agent/NodeDetector.kt
+++ b/agent/src/main/java/com/jonnyzzz/teamcity/plugins/node/agent/NodeDetector.kt
@@ -40,7 +40,7 @@ class NodeToolsDetector(events: EventDispatcher<AgentLifeCycleListener>,
   fun detectNVMTool() {
     with(config.systemInfo) {
       when {
-        isWindows && !File(System.getenv("NVM_HOME") + "\\nvm\\nvm.exe").isFile -> {
+        isWindows && !File(System.getenv("NVM_HOME") + "\\nvm.exe").isFile -> {
           log4j(javaClass).info("Node NVM installer runner is not available.")
         }
 

--- a/agent/src/main/java/com/jonnyzzz/teamcity/plugins/node/agent/NodeDetector.kt
+++ b/agent/src/main/java/com/jonnyzzz/teamcity/plugins/node/agent/NodeDetector.kt
@@ -40,8 +40,10 @@ class NodeToolsDetector(events: EventDispatcher<AgentLifeCycleListener>,
   fun detectNVMTool() {
     with(config.systemInfo) {
       when {
-        isWindows && !File(System.getenv("NVM_HOME") + "\\nvm.exe").isFile -> {
-          log4j(javaClass).info("Node NVM installer runner is not available.")
+        isWindows
+          && System.getenv("APPDATA")?.let { File(it, "\\nvm\\nvm.exe").isFile } != true
+          && System.getenv("NVM_HOME")?.let { File(it, "\\nvm.exe").isFile } != true -> {
+            log4j(javaClass).info("Node NVM installer runner is not available.")
         }
 
         !(isMac || isUnix || isWindows) -> {

--- a/agent/src/main/java/com/jonnyzzz/teamcity/plugins/node/agent/nvm/NVM.kt
+++ b/agent/src/main/java/com/jonnyzzz/teamcity/plugins/node/agent/nvm/NVM.kt
@@ -97,7 +97,6 @@ class NVMRunner(val downloader : NVMDownloader,
     val fromSource = if(!context.runnerParameters[bean.NVMSource].isEmptyOrSpaces()) "-s " else ""
     val url = context.runnerParameters[bean.NVMURL] ?: bean.NVM_Creatonix
     val isWindows = runningBuild.agentConfiguration.systemInfo.isWindows
-
     val installCmd = "nvm install $fromSource $version"
     val useCmd = "nvm use $version"
 
@@ -112,17 +111,16 @@ class NVMRunner(val downloader : NVMDownloader,
         
         script("Install", "Installing Node.js v$version",nvmHome.path) {
           if (isWindows)
-              installCmd
+            installCmd
           else
             ". $nvmHome/nvm.sh" n installCmd
         }
 
         script("Use", "Selecting Node.js v$version", nvmHome.path) {
           if (isWindows)
-            // executing ${TEAMCITY_CAPTURE_ENV} in Windows has not effect like it does in Linux, as agent parameters
+            // Executing ${TEAMCITY_CAPTURE_ENV} in Windows has no effect like it does in Linux, as agent parameters
             // still displays TEAMCITY_CAPTURE_ENV as populated, and its value transfers between build steps without
-            // with the need for an 'eval' substitute in Windows
-
+            // the need for an 'eval' substitute
             useCmd
           else
             ". $nvmHome/nvm.sh" n useCmd n "eval \${TEAMCITY_CAPTURE_ENV}"

--- a/agent/src/main/java/com/jonnyzzz/teamcity/plugins/node/agent/nvm/NVM.kt
+++ b/agent/src/main/java/com/jonnyzzz/teamcity/plugins/node/agent/nvm/NVM.kt
@@ -96,7 +96,7 @@ class NVMRunner(val downloader : NVMDownloader,
     val version = context.runnerParameters[bean.NVMVersion]
     val fromSource = if(!context.runnerParameters[bean.NVMSource].isEmptyOrSpaces()) "-s " else ""
     val url = context.runnerParameters[bean.NVMURL] ?: bean.NVM_Creatonix
-    var isWindows = runningBuild.agentConfiguration.systemInfo.isWindows
+    val isWindows = runningBuild.agentConfiguration.systemInfo.isWindows
 
     return context.logging {
       facade.compositeBuildProcess(runningBuild) {


### PR DESCRIPTION
As outlined in this issue: https://github.com/jonnyzzz/TeamCity.Node/issues/133 the Windows setup is incomplete. 

The following outlines the changes made in the pull request to fix this, and to complete the Windows NVM Installer runner.

- The check for the nvm.exe is incorrect, `NVM_HOME` is the path needed to perform the check, rather than `APPDATA`
- Bash scripts and commands not supported by Windows were used as part of the `nvm install` and `nvm use` commands. There is now a check to see if the agent is Windows, and instead runs commands supported in Windows. 
- The `eval` command was used, this is not supported in Windows, and its purpose offers no extra to a Windows agents. When checking **Agent Parameters** > **Environment Variables** `TEAMCITY_CAPTURE_ENV` is always populated, so this environment property will, and does, continue to pass between build steps