### PR TITLE
performance optimization related to TW-46577 and TW-57578

### DIFF
--- a/server/src/main/java/com/jonnyzzz/teamcity/plugins/node/server/NVM.kt
+++ b/server/src/main/java/com/jonnyzzz/teamcity/plugins/node/server/NVM.kt
@@ -26,6 +26,7 @@ import jetbrains.buildServer.serverSide.buildDistribution.AgentsFilterContext
 import jetbrains.buildServer.serverSide.buildDistribution.AgentsFilterResult
 import jetbrains.buildServer.serverSide.BuildPromotionManager
 import jetbrains.buildServer.requirements.RequirementType
+import jetbrains.buildServer.serverSide.BuildPromotion
 import jetbrains.buildServer.serverSide.buildDistribution.SimpleWaitReason
 
 /**
@@ -65,8 +66,11 @@ class NVMBuildStartPrecondition(val promos : BuildPromotionManager) : StartingBu
 
   override fun filterAgents(context: AgentsFilterContext): AgentsFilterResult {
     val result = AgentsFilterResult()
-    val promoId = context.getStartingBuild().getBuildPromotionInfo().getId()
-    val buildType = promos.findPromotionById(promoId)?.getBuildType()
+    val promo = context.getStartingBuild().getBuildPromotionInfo()
+
+    if (promo !is BuildPromotion) return result
+
+    val buildType = promo.getBuildType()
 
     if (buildType == null) return result
 


### PR DESCRIPTION
Currently NVMBuildStartPrecondition.filterAgents constantly tries to find a promotion by id. This lookup requires read lock on build promotion cache. If at the same time there is a thread which modifies build queue, then processing of the queue will be slowed down.

Instead of looking for a promotion by id, we can cast the returned object to BuildPromotion.